### PR TITLE
[DE-1071] Filter pushdown

### DIFF
--- a/spotbugs/spotbugs-exclude.xml
+++ b/spotbugs/spotbugs-exclude.xml
@@ -35,4 +35,9 @@
         <Bug pattern="SE_BAD_FIELD"/>
     </Match>
 
+    <Match>
+        <Class name="com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization.ArangoStepStrategy"/>
+        <Bug pattern="SING_SINGLETON_IMPLEMENTS_SERIALIZABLE"/>
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/client/ArangoDBGraphClient.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/client/ArangoDBGraphClient.java
@@ -131,7 +131,7 @@ public class ArangoDBGraphClient {
      */
     public Stream<VertexData> getGraphVertices(final List<ElementId> ids) {
         logger.debug("Get all {} graph vertices, filtered by ids: {}", config.graphName, ids);
-        return getGraphDocuments(ids, EmptyFilter.INSTANCE, config.vertices, VertexData.class);
+        return getGraphDocuments(ids, EmptyFilter.instance(), config.vertices, VertexData.class);
     }
 
     /**
@@ -142,7 +142,7 @@ public class ArangoDBGraphClient {
      */
     public Stream<EdgeData> getGraphEdges(List<ElementId> ids) {
         logger.debug("Get all {} graph edges, filtered by ids: {}", config.graphName, ids);
-        return getGraphDocuments(ids, EmptyFilter.INSTANCE, config.edges, EdgeData.class);
+        return getGraphDocuments(ids, EmptyFilter.instance(), config.edges, EdgeData.class);
     }
 
     private <V> Stream<V> getGraphDocuments(List<ElementId> ids, ArangoFilter filter, Set<String> colNames, Class<V> clazz) {

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/AndFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/AndFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AndFilter implements ArangoFilter {
+    private final List<ArangoFilter> filters;
+
+    public static ArangoFilter of(Collection<ArangoFilter> filters) {
+        List<ArangoFilter> supportedFilters = filters.stream()
+                .filter(it -> it.getSupport() != FilterSupport.NONE)
+                .collect(Collectors.toList());
+        if (supportedFilters.isEmpty()) {
+            return EmptyFilter.INSTANCE;
+        } else if (supportedFilters.size() == 1) {
+            return supportedFilters.get(0);
+        } else {
+            return new AndFilter(supportedFilters);
+        }
+    }
+
+    private AndFilter(List<ArangoFilter> filters) {
+        this.filters = filters;
+    }
+
+    /**
+     * +---------++---------+---------+---------+
+     * |   AND   ||  FULL   | PARTIAL |  NONE   |
+     * +---------++---------+---------+---------+
+     * | FULL    || FULL    | PARTIAL | PARTIAL |
+     * | PARTIAL || PARTIAL | PARTIAL | PARTIAL |
+     * | NONE    || PARTIAL | PARTIAL | NONE    |
+     * +---------++---------+---------+---------+
+     */
+    @Override
+    public FilterSupport getSupport() {
+        if (filters.stream().map(ArangoFilter::getSupport).allMatch(FilterSupport.FULL::equals)) {
+            return FilterSupport.FULL;
+        } else {
+            return FilterSupport.PARTIAL;
+        }
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return filters.stream()
+                .map(it -> it.toAql(variableName))
+                .collect(Collectors.joining(" AND ", "(", ")"));
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/AndFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/AndFilter.java
@@ -28,7 +28,7 @@ public class AndFilter implements ArangoFilter {
                 .filter(it -> it.getSupport() != FilterSupport.NONE)
                 .collect(Collectors.toList());
         if (supportedFilters.isEmpty()) {
-            return EmptyFilter.INSTANCE;
+            return EmptyFilter.instance();
         } else if (supportedFilters.size() == 1) {
             return supportedFilters.get(0);
         } else {

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/ArangoFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/ArangoFilter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
+import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public interface ArangoFilter {
+    static ArangoFilter of(String key, P<?> p) {
+        String pName = p.getPredicateName();
+        switch (pName) {
+            case "eq":
+                return new CompareEqFilter(key, p.getValue());
+            case "neq":
+                return NotFilter.of(new CompareEqFilter(key, p.getValue()));
+            case "lt":
+                return new CompareLtFilter(key, p.getValue());
+            case "lte":
+                return OrFilter.of(Arrays.asList(new CompareLtFilter(key, p.getValue()), new CompareEqFilter(key, p.getValue())));
+            case "gt":
+                return new CompareGtFilter(key, p.getValue());
+            case "gte":
+                return OrFilter.of(Arrays.asList(new CompareGtFilter(key, p.getValue()), new CompareEqFilter(key, p.getValue())));
+            case "within":
+                return new ContainsWithinFilter(key, (Collection<?>) p.getValue());
+            case "without":
+                return NotFilter.of(new ContainsWithinFilter(key, (Collection<?>) p.getValue()));
+            case "containing":
+                return new TextContainingFilter(key, (String) p.getValue());
+            case "notContaining":
+                return NotFilter.of(new TextContainingFilter(key, (String) p.getValue()));
+            case "endingWith":
+                return new TextRegexFilter(key, p.getValue() + "$");
+            case "notEndingWith":
+                return NotFilter.of(new TextRegexFilter(key, p.getValue() + "$"));
+            case "startingWith":
+                return new TextStartingWithFilter(key, (String) p.getValue());
+            case "notStartingWith":
+                return NotFilter.of(new TextStartingWithFilter(key, (String) p.getValue()));
+            case "regex":
+                return new TextRegexFilter(key, (String) p.getValue());
+            case "notRegex":
+                return NotFilter.of(new TextRegexFilter(key, (String) p.getValue()));
+            case "or":
+                if (p instanceof OrP) {
+                    return OrFilter.of(((OrP<?>) p).getPredicates().stream()
+                            .map(it -> of(key, it))
+                            .collect(Collectors.toList()));
+                }
+                throw new UnsupportedOperationException("Unsupported predicate: " + p);
+            case "and":
+                if (p instanceof AndP) {
+                    return AndFilter.of(((AndP<?>) p).getPredicates().stream()
+                            .map(it -> of(key, it))
+                            .collect(Collectors.toList()));
+                }
+                throw new UnsupportedOperationException("Unsupported predicate: " + p);
+            default:
+                throw new UnsupportedOperationException("Unsupported predicate: " + p);
+        }
+    }
+
+    FilterSupport getSupport();
+
+    String toAql(String variableName);
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/ArangoFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/ArangoFilter.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public interface ArangoFilter {
@@ -49,9 +50,9 @@ public interface ArangoFilter {
             case "notContaining":
                 return NotFilter.of(new TextContainingFilter(key, (String) p.getValue()));
             case "endingWith":
-                return new TextRegexFilter(key, p.getValue() + "$");
+                return new TextRegexFilter(key, Pattern.quote((String) p.getValue()) + "$");
             case "notEndingWith":
-                return NotFilter.of(new TextRegexFilter(key, p.getValue() + "$"));
+                return NotFilter.of(new TextRegexFilter(key, Pattern.quote((String) p.getValue()) + "$"));
             case "startingWith":
                 return new TextStartingWithFilter(key, (String) p.getValue());
             case "notStartingWith":

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/CompareEqFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/CompareEqFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Objects;
+
+public class CompareEqFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final Value value;
+
+    public CompareEqFilter(String attribute, Object value) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(value);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return value.getSupport();
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "`" + variableName + "`.`" + attribute + "` == " + value.toAql();
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/CompareGtFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/CompareGtFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Objects;
+
+public class CompareGtFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final Value value;
+
+    public CompareGtFilter(String attribute, Object value) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(value);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return value.getSupport();
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "`" + variableName + "`.`" + attribute + "` > " + value.toAql();
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/CompareLtFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/CompareLtFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Objects;
+
+public class CompareLtFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final Value value;
+
+    public CompareLtFilter(String attribute, Object value) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(value);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return value.getSupport();
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "`" + variableName + "`.`" + attribute + "` < " + value.toAql();
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/ContainsWithinFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/ContainsWithinFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.ArrayValue;
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class ContainsWithinFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final ArrayValue value;
+
+    public ContainsWithinFilter(String attribute, Collection<?> values) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(values);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return value.getSupport();
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "`" + variableName + "`.`" + attribute + "` IN " + value.toAql();
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/EmptyFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/EmptyFilter.java
@@ -17,7 +17,11 @@
 package com.arangodb.tinkerpop.gremlin.process.filter;
 
 public class EmptyFilter implements ArangoFilter {
-    public static final EmptyFilter INSTANCE = new EmptyFilter();
+    private static final EmptyFilter INSTANCE = new EmptyFilter();
+
+    public static EmptyFilter instance() {
+        return INSTANCE;
+    }
 
     private EmptyFilter() {
     }

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/EmptyFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/EmptyFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+public class EmptyFilter implements ArangoFilter {
+    public static final EmptyFilter INSTANCE = new EmptyFilter();
+
+    private EmptyFilter() {
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.NONE;
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/FilterSupport.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/FilterSupport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+public enum FilterSupport {
+    /**
+     * it filters exactly
+     */
+    FULL,
+
+    /**
+     * it filters partially i.e., returns more elements than expected
+     */
+    PARTIAL,
+
+
+    /**
+     * not supported
+     */
+    NONE
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/NotFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/NotFilter.java
@@ -21,7 +21,7 @@ public class NotFilter implements ArangoFilter {
 
     public static ArangoFilter of(ArangoFilter filter) {
         if (filter.getSupport() != FilterSupport.FULL) {
-            return EmptyFilter.INSTANCE;
+            return EmptyFilter.instance();
         }
         return new NotFilter(filter);
     }

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/NotFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/NotFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+public class NotFilter implements ArangoFilter {
+    private final ArangoFilter filter;
+
+    public static ArangoFilter of(ArangoFilter filter) {
+        if (filter.getSupport() != FilterSupport.FULL) {
+            return EmptyFilter.INSTANCE;
+        }
+        return new NotFilter(filter);
+    }
+
+    private NotFilter(ArangoFilter filter) {
+        this.filter = filter;
+    }
+
+    /**
+     * +---------++---------+
+     * |   v     || NOT(v)  |
+     * +---------++---------+
+     * | FULL    || FULL    |
+     * | PARTIAL || NONE    |
+     * | NONE    || NONE    |
+     * +---------++---------+
+     */
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "NOT(" + filter.toAql(variableName) + ")";
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/OrFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/OrFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OrFilter implements ArangoFilter {
+    private final List<ArangoFilter> filters;
+
+    public static ArangoFilter of(Collection<ArangoFilter> filters) {
+        List<ArangoFilter> supportedFilters = filters.stream()
+                .filter(it -> it.getSupport() != FilterSupport.NONE)
+                .collect(Collectors.toList());
+        if (supportedFilters.isEmpty()) {
+            return EmptyFilter.INSTANCE;
+        } else if (supportedFilters.size() == 1) {
+            return supportedFilters.get(0);
+        } else {
+            return new OrFilter(supportedFilters);
+        }
+    }
+
+    private OrFilter(List<ArangoFilter> filters) {
+        this.filters = filters;
+    }
+
+    /**
+     * +---------++---------+---------+------+
+     * |   OR    ||  FULL   | PARTIAL | NONE |
+     * +---------++---------+---------+------+
+     * | FULL    || FULL    | PARTIAL | NONE |
+     * | PARTIAL || PARTIAL | PARTIAL | NONE |
+     * | NONE    || NONE    | NONE    | NONE |
+     * +---------++---------+---------+------+
+     */
+    @Override
+    public FilterSupport getSupport() {
+        if (filters.stream().map(ArangoFilter::getSupport).allMatch(FilterSupport.FULL::equals)) {
+            return FilterSupport.FULL;
+        } else {
+            return FilterSupport.PARTIAL;
+        }
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return filters.stream()
+                .map(it -> it.toAql(variableName))
+                .collect(Collectors.joining(" OR ", "(", ")"));
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/OrFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/OrFilter.java
@@ -28,7 +28,7 @@ public class OrFilter implements ArangoFilter {
                 .filter(it -> it.getSupport() != FilterSupport.NONE)
                 .collect(Collectors.toList());
         if (supportedFilters.isEmpty()) {
-            return EmptyFilter.INSTANCE;
+            return EmptyFilter.instance();
         } else if (supportedFilters.size() == 1) {
             return supportedFilters.get(0);
         } else {

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/TextContainingFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/TextContainingFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.StringValue;
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Objects;
+
+public class TextContainingFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final StringValue value;
+
+    public TextContainingFilter(String attribute, String value) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(value);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "CONTAINS(`" + variableName + "`.`" + attribute + "`, " + value.toAql() + ")";
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/TextRegexFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/TextRegexFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.StringValue;
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Objects;
+
+public class TextRegexFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final StringValue value;
+
+    public TextRegexFilter(String attribute, String value) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(value);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "REGEX_TEST(`" + variableName + "`.`" + attribute + "`, " + value.toAql() + ")";
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/TextStartingWithFilter.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/filter/TextStartingWithFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.filter;
+
+
+import com.arangodb.tinkerpop.gremlin.process.value.StringValue;
+import com.arangodb.tinkerpop.gremlin.process.value.Value;
+
+import java.util.Objects;
+
+public class TextStartingWithFilter implements ArangoFilter {
+
+    private final String attribute;
+    private final StringValue value;
+
+    public TextStartingWithFilter(String attribute, String value) {
+        Objects.requireNonNull(attribute, "attribute cannot be null");
+        if (attribute.isEmpty()) {
+            throw new IllegalArgumentException("attribute cannot be empty");
+        }
+        this.attribute = attribute;
+        this.value = Value.of(value);
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+
+    @Override
+    public String toAql(String variableName) {
+        return "STARTS_WITH(`" + variableName + "`.`" + attribute + "`, " + value.toAql() + ")";
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/step/AQLStartStep.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/step/AQLStartStep.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.arangodb.tinkerpop.gremlin.process.traversal.step.sideEffect;
+package com.arangodb.tinkerpop.gremlin.process.traversal.step;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.StartStep;

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/step/sideEffect/ArangoStep.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/step/sideEffect/ArangoStep.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.traversal.step.sideEffect;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.*;
+import com.arangodb.tinkerpop.gremlin.structure.ArangoDBEdge;
+import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraph;
+import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraphConfig;
+import com.arangodb.tinkerpop.gremlin.structure.ArangoDBVertex;
+import com.arangodb.tinkerpop.gremlin.utils.ArangoDBUtil;
+import com.arangodb.tinkerpop.gremlin.utils.Fields;
+import org.apache.tinkerpop.gremlin.process.traversal.*;
+import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ArangoStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder {
+
+    private final List<HasContainer> hasContainers = new ArrayList<>();
+
+    public ArangoStep(final GraphStep<S, E> originalGraphStep) {
+        super(originalGraphStep.getTraversal(), originalGraphStep.getReturnClass(), originalGraphStep.isStartStep(), originalGraphStep.getIds());
+        originalGraphStep.getLabels().forEach(this::addLabel);
+        setIteratorSupplier(this::elements);
+    }
+
+    @Override
+    public String toString() {
+        if (hasContainers.isEmpty())
+            return super.toString();
+        else
+            return 0 == ids.length ?
+                    StringFactory.stepString(this, returnClass.getSimpleName().toLowerCase(), hasContainers) :
+                    StringFactory.stepString(this, returnClass.getSimpleName().toLowerCase(), Arrays.toString(ids), hasContainers);
+    }
+
+    @Override
+    public List<HasContainer> getHasContainers() {
+        return Collections.unmodifiableList(hasContainers);
+    }
+
+    @Override
+    public void addHasContainer(final HasContainer hasContainer) {
+        normalizePredicate(hasContainer.getPredicate());
+        hasContainers.add(hasContainer);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ hasContainers.hashCode();
+    }
+
+    private void normalizePredicate(P<?> p) {
+        if (p instanceof ConnectiveP) {
+            ((ConnectiveP<?>) p).getPredicates().forEach(this::normalizePredicate);
+        } else {
+            p.setValue(ArangoDBUtil.normalizeValue(p.getValue()));
+        }
+    }
+
+    private String mapKey(String key, ArangoDBGraphConfig config) {
+        if (key.equals(T.label.getAccessor())) {
+            return config.labelField;
+        } else if (key.equals(T.id.getAccessor())) {
+            if (config.graphType == ArangoDBGraphConfig.GraphType.SIMPLE) {
+                return Fields.KEY;
+            } else {
+                return Fields.ID;
+            }
+        } else {
+            return key;
+        }
+    }
+
+    private ArangoFilter getArangoFilter(ArangoDBGraphConfig config) {
+        return AndFilter.of(hasContainers.stream()
+                .filter(it -> it.getKey() != null)
+                .filter(it -> config.graphType != ArangoDBGraphConfig.GraphType.COMPLEX || !T.label.getAccessor().equals(it.getKey()))
+                .map(it -> ArangoFilter.of(mapKey(it.getKey(), config), it.getPredicate()))
+                .filter(it -> it.getSupport() != FilterSupport.NONE)
+                .collect(Collectors.toList()));
+    }
+
+    private Set<String> getCollections(ArangoDBGraphConfig config) {
+        Set<String> collections;
+        if (Vertex.class.isAssignableFrom(returnClass)) {
+            collections = config.vertices;
+        } else if (Edge.class.isAssignableFrom(returnClass)) {
+            collections = config.edges;
+        } else {
+            throw new UnsupportedOperationException("Unsupported return type: " + returnClass);
+        }
+
+        if (config.graphType == ArangoDBGraphConfig.GraphType.SIMPLE) {
+            return collections;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<? extends P<String>> labelFilters = hasContainers.stream()
+                .filter(it -> T.label.getAccessor().equals(it.getKey()))
+                .map(it -> (P<String>) it.getPredicate())
+                .collect(Collectors.toList());
+
+        return collections.stream()
+                .filter(it -> labelFilters.stream().allMatch(x -> x.test(it)))
+                .collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterator<E> elements() {
+        if (null == ids)
+            return Collections.emptyIterator();
+
+        ArangoDBGraph graph = (ArangoDBGraph) getTraversal().getGraph().get();
+        ArangoDBGraphConfig config = graph.config;
+        convertElementsToIds();
+        Stream<E> res;
+        if (Vertex.class.isAssignableFrom(returnClass)) {
+            res = graph.getClient().getGraphVertices(graph.idFactory.parseVertexIds(ids), getArangoFilter(config), getCollections(config))
+                    .map(it -> (E) new ArangoDBVertex(graph, it));
+        } else if (Edge.class.isAssignableFrom(returnClass)) {
+            res = graph.getClient().getGraphEdges(graph.idFactory.parseEdgeIds(ids), getArangoFilter(config), getCollections(config))
+                    .map(it -> (E) new ArangoDBEdge(graph, it));
+        } else {
+            throw new UnsupportedOperationException("Unsupported return type: " + returnClass);
+        }
+
+        return res
+                .filter(it -> HasContainer.testAll(it, hasContainers))
+                .iterator();
+    }
+
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/strategy/optimization/ArangoStepStrategy.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/strategy/optimization/ArangoStepStrategy.java
@@ -16,7 +16,7 @@
 
 package com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization;
 
-import com.arangodb.tinkerpop.gremlin.process.traversal.step.sideEffect.ArangoStep;
+import com.arangodb.tinkerpop.gremlin.process.traversal.step.ArangoStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
@@ -30,7 +30,16 @@ import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 
 public final class ArangoStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
 
-    public static final ArangoStepStrategy INSTANCE = new ArangoStepStrategy();
+    private static final ArangoStepStrategy INSTANCE = new ArangoStepStrategy();
+
+    public static ArangoStepStrategy instance() {
+        return INSTANCE;
+    }
+
+    // Ensure the singleton property is maintained during deserialization
+    private Object readResolve() {
+        return INSTANCE;
+    }
 
     private ArangoStepStrategy() {
     }

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/strategy/optimization/ArangoStepStrategy.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/traversal/strategy/optimization/ArangoStepStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization;
+
+import com.arangodb.tinkerpop.gremlin.process.traversal.step.sideEffect.ArangoStep;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+public final class ArangoStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
+
+    public static final ArangoStepStrategy INSTANCE = new ArangoStepStrategy();
+
+    private ArangoStepStrategy() {
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public void apply(final Traversal.Admin<?, ?> traversal) {
+        for (final GraphStep originalGraphStep : TraversalHelper.getStepsOfClass(GraphStep.class, traversal)) {
+            final ArangoStep<?, ?> arangoStep = new ArangoStep<>(originalGraphStep);
+            TraversalHelper.replaceStep(originalGraphStep, arangoStep, traversal);
+            Step<?, ?> currentStep = arangoStep.getNextStep();
+            while (currentStep instanceof HasStep || currentStep instanceof NoOpBarrierStep) {
+                if (currentStep instanceof HasStep) {
+                    for (final HasContainer hasContainer : ((HasContainerHolder) currentStep).getHasContainers()) {
+                        if (!GraphStep.processHasContainerIds(arangoStep, hasContainer))
+                            arangoStep.addHasContainer(hasContainer);
+                    }
+                    TraversalHelper.copyLabels(currentStep, currentStep.getPreviousStep(), false);
+                    traversal.removeStep(currentStep);
+                }
+                currentStep = currentStep.getNextStep();
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/ArrayValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/ArrayValue.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ArrayValue implements Value {
+    private final List<Value> values;
+
+    ArrayValue(Collection<?> values) {
+        this.values = values.stream()
+                .map(Value::of)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<?> value() {
+        return values.stream()
+                .map(Value::value)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        if (values.stream().map(Value::getSupport).anyMatch(FilterSupport.NONE::equals)) {
+            return FilterSupport.NONE;
+        } else if (values.stream().map(Value::getSupport).anyMatch(FilterSupport.PARTIAL::equals)) {
+            return FilterSupport.PARTIAL;
+        } else {
+            return FilterSupport.FULL;
+        }
+    }
+
+    @Override
+    public String toAql() {
+        return values.stream()
+                .map(Value::toAql)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/BooleanValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/BooleanValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+public class BooleanValue implements Value {
+    private final boolean value;
+
+    BooleanValue(boolean value) {
+        this.value = value;
+    }
+
+    @Override
+    public Boolean value() {
+        return value;
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/DoubleValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/DoubleValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+public class DoubleValue implements Value {
+    private final Double value;
+
+    DoubleValue(Double value) {
+        this.value = value;
+    }
+
+    @Override
+    public Double value() {
+        return value;
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/IntegerValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/IntegerValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+public class IntegerValue implements Value {
+    private final Integer value;
+
+    IntegerValue(Integer value) {
+        this.value = value;
+    }
+
+    @Override
+    public Integer value() {
+        return value;
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/LongValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/LongValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+public class LongValue implements Value {
+    private final Long value;
+
+    LongValue(Long value) {
+        this.value = value;
+    }
+
+    @Override
+    public Long value() {
+        return value;
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/MapValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/MapValue.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MapValue implements Value {
+    private final Map<String, Value> values;
+
+    MapValue(Map<?, ?> values) {
+        this.values = values.entrySet().stream()
+                .peek(it -> {
+                    if (!(it.getKey() instanceof String)) {
+                        throw new IllegalArgumentException("key must be a string");
+                    }
+                })
+                .collect(Collectors.toMap(
+                        e -> (String) e.getKey(),
+                        e -> Value.of(e.getValue())
+                ));
+    }
+
+    @Override
+    public Map<String, ?> value() {
+        return values.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().value()
+                ));
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        if (values.values().stream().map(Value::getSupport).anyMatch(FilterSupport.NONE::equals)) {
+            return FilterSupport.NONE;
+        } else if (values.values().stream().map(Value::getSupport).anyMatch(FilterSupport.PARTIAL::equals)) {
+            return FilterSupport.PARTIAL;
+        } else {
+            return FilterSupport.FULL;
+        }
+    }
+
+    @Override
+    public String toAql() {
+        return values.entrySet().stream()
+                .map(it -> "\"" + it.getKey() + "\": " + it.getValue().toAql())
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/NullValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/NullValue.java
@@ -19,7 +19,11 @@ package com.arangodb.tinkerpop.gremlin.process.value;
 import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
 
 public class NullValue implements Value {
-    public static final NullValue INSTANCE = new NullValue();
+    private static final NullValue INSTANCE = new NullValue();
+
+    public static NullValue instance() {
+        return INSTANCE;
+    }
 
     private NullValue() {
     }

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/NullValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/NullValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+public class NullValue implements Value {
+    public static final NullValue INSTANCE = new NullValue();
+
+    private NullValue() {
+    }
+
+    @Override
+    public Void value() {
+        return null;
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.PARTIAL;
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/StringValue.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/StringValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+
+public class StringValue implements Value {
+    private final String value;
+
+    StringValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public FilterSupport getSupport() {
+        return FilterSupport.FULL;
+    }
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/Value.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/Value.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.process.value;
+
+import com.arangodb.shaded.fasterxml.jackson.core.JsonProcessingException;
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+import com.arangodb.tinkerpop.gremlin.utils.ArangoDBUtil;
+import org.apache.tinkerpop.gremlin.structure.Property;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static com.arangodb.tinkerpop.gremlin.utils.ArangoDBUtil.MAPPER;
+
+public interface Value {
+
+    Object value();
+
+    FilterSupport getSupport();
+
+    default String toAql() {
+        try {
+            return MAPPER.writeValueAsString(value());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Value of(Object value) {
+        if (value == null) {
+            return NullValue.INSTANCE;
+        } else if (value instanceof Boolean) {
+            return new BooleanValue((Boolean) value);
+        } else if (value instanceof Integer) {
+            return new IntegerValue((Integer) value);
+        } else if (value instanceof Double) {
+            return new DoubleValue((Double) value);
+        } else if (value instanceof Long) {
+            return new LongValue((Long) value);
+        } else if (value instanceof String) {
+            return of((String) value);
+        } else if (value instanceof Map) {
+            return new MapValue((Map<?, ?>) value);
+        } else if (value instanceof Collection) {
+            return of((Collection<?>) value);
+        } else if (value.getClass().isArray()) {
+            return new ArrayValue(ArangoDBUtil.arrayToList(value));
+        } else {
+            throw Property.Exceptions.dataTypeOfPropertyValueNotSupported(value);
+        }
+    }
+
+    static StringValue of(String value) {
+        return new StringValue(value);
+    }
+
+    static ArrayValue of(Collection<?> value) {
+        return new ArrayValue(value);
+    }
+
+}

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/Value.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/process/value/Value.java
@@ -42,7 +42,7 @@ public interface Value {
 
     static Value of(Object value) {
         if (value == null) {
-            return NullValue.INSTANCE;
+            return NullValue.instance();
         } else if (value instanceof Boolean) {
             return new BooleanValue((Boolean) value);
         } else if (value instanceof Integer) {

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBEdge.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBEdge.java
@@ -27,7 +27,7 @@ import java.util.*;
 
 public class ArangoDBEdge extends ArangoDBSimpleElement<EdgeData> implements Edge, ArangoDBPersistentElement {
 
-    ArangoDBEdge(ArangoDBGraph graph, EdgeData data) {
+    public ArangoDBEdge(ArangoDBGraph graph, EdgeData data) {
         super(graph, data);
     }
 

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBGraph.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBGraph.java
@@ -22,7 +22,7 @@ import com.arangodb.ArangoDatabase;
 import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.tinkerpop.gremlin.PackageVersion;
 import com.arangodb.tinkerpop.gremlin.persistence.*;
-import com.arangodb.tinkerpop.gremlin.process.traversal.step.sideEffect.AQLStartStep;
+import com.arangodb.tinkerpop.gremlin.process.traversal.step.AQLStartStep;
 import com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization.ArangoStepStrategy;
 import com.arangodb.tinkerpop.gremlin.utils.ArangoDBUtil;
 import org.apache.commons.configuration2.Configuration;
@@ -45,7 +45,7 @@ public class ArangoDBGraph implements Graph {
 
     static {
         TraversalStrategies.GlobalCache.registerStrategies(ArangoDBGraph.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
-                .addStrategies(ArangoStepStrategy.INSTANCE));
+                .addStrategies(ArangoStepStrategy.instance()));
     }
 
     public static final String GRAPH_VARIABLES_COLLECTION = "TINKERPOP-GRAPH-VARIABLES";
@@ -53,7 +53,7 @@ public class ArangoDBGraph implements Graph {
     private static final Features FEATURES = new ArangoDBGraphFeatures();
 
     private final ArangoDBGraphClient client;
-    public final ElementIdFactory idFactory;
+    private final ElementIdFactory idFactory;
     public final ArangoDBGraphConfig config;
 
     /**
@@ -144,6 +144,10 @@ public class ArangoDBGraph implements Graph {
     @Override
     public Configuration configuration() {
         return config.configuration;
+    }
+
+    public ElementIdFactory getIdFactory() {
+        return idFactory;
     }
 
     @Override

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBGraph.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBGraph.java
@@ -23,9 +23,11 @@ import com.arangodb.model.AqlQueryOptions;
 import com.arangodb.tinkerpop.gremlin.PackageVersion;
 import com.arangodb.tinkerpop.gremlin.persistence.*;
 import com.arangodb.tinkerpop.gremlin.process.traversal.step.sideEffect.AQLStartStep;
+import com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization.ArangoStepStrategy;
 import com.arangodb.tinkerpop.gremlin.utils.ArangoDBUtil;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.DefaultGraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.*;
@@ -40,12 +42,18 @@ import com.arangodb.tinkerpop.gremlin.client.ArangoDBGraphClient;
 import com.arangodb.ArangoDB;
 
 public class ArangoDBGraph implements Graph {
+
+    static {
+        TraversalStrategies.GlobalCache.registerStrategies(ArangoDBGraph.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
+                .addStrategies(ArangoStepStrategy.INSTANCE));
+    }
+
     public static final String GRAPH_VARIABLES_COLLECTION = "TINKERPOP-GRAPH-VARIABLES";
     private static final Logger LOGGER = LoggerFactory.getLogger(ArangoDBGraph.class);
     private static final Features FEATURES = new ArangoDBGraphFeatures();
 
     private final ArangoDBGraphClient client;
-    private final ElementIdFactory idFactory;
+    public final ElementIdFactory idFactory;
     public final ArangoDBGraphConfig config;
 
     /**
@@ -140,14 +148,14 @@ public class ArangoDBGraph implements Graph {
 
     @Override
     public Iterator<Edge> edges(Object... edgeIds) {
-        return getClient().getGraphEdges(idFactory.parseEdgeIds(edgeIds)).stream()
+        return getClient().getGraphEdges(idFactory.parseEdgeIds(edgeIds))
                 .map(it -> (Edge) new ArangoDBEdge(this, it))
                 .iterator();
     }
 
     @Override
     public Iterator<Vertex> vertices(Object... vertexIds) {
-        return getClient().getGraphVertices(idFactory.parseVertexIds(vertexIds)).stream()
+        return getClient().getGraphVertices(idFactory.parseVertexIds(vertexIds))
                 .map(it -> (Vertex) new ArangoDBVertex(this, it))
                 .iterator();
     }
@@ -242,7 +250,7 @@ public class ArangoDBGraph implements Graph {
      */
     public <E> GraphTraversal<?, E> aql(final String query, final Map<String, ?> parameters, final AqlQueryOptions options) {
         GraphTraversal.Admin<?, E> traversal = new DefaultGraphTraversal<>(this);
-        traversal.addStep(new AQLStartStep(traversal, query, client.query(query, parameters, options)));
+        traversal.addStep(new AQLStartStep(traversal, query, client.query(query, parameters, options).iterator()));
         return traversal;
     }
 

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBVertex.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/structure/ArangoDBVertex.java
@@ -30,7 +30,7 @@ import static com.arangodb.tinkerpop.gremlin.structure.ArangoDBElement.Exception
 
 public class ArangoDBVertex extends ArangoDBElement<VertexPropertyData, VertexData> implements Vertex, ArangoDBPersistentElement {
 
-    ArangoDBVertex(ArangoDBGraph graph, VertexData data) {
+    public ArangoDBVertex(ArangoDBGraph graph, VertexData data) {
         super(graph, data);
     }
 
@@ -102,8 +102,9 @@ public class ArangoDBVertex extends ArangoDBElement<VertexPropertyData, VertexDa
         if (edgeCollections.isEmpty()) {
             return Collections.emptyIterator();
         }
-        return IteratorUtils.map(graph.getClient().getVertexEdges(elementId(), edgeCollections, direction, edgeLabels),
-                it -> new ArangoDBEdge(graph, it));
+        return graph.getClient().getVertexEdges(elementId(), edgeCollections, direction, edgeLabels)
+                .map(it -> (Edge) new ArangoDBEdge(graph, it))
+                .iterator();
     }
 
     @Override
@@ -114,8 +115,9 @@ public class ArangoDBVertex extends ArangoDBElement<VertexPropertyData, VertexDa
         if (edgeCollections.isEmpty()) {
             return Collections.emptyIterator();
         }
-        return IteratorUtils.map(graph.getClient().getVertexNeighbors(elementId(), edgeCollections, direction, edgeLabels),
-                it -> new ArangoDBVertex(graph, it));
+        return graph.getClient().getVertexNeighbors(elementId(), edgeCollections, direction, edgeLabels)
+                .map(it -> (Vertex) new ArangoDBVertex(graph, it))
+                .iterator();
     }
 
     @Override

--- a/src/main/java/com/arangodb/tinkerpop/gremlin/utils/ArangoDBUtil.java
+++ b/src/main/java/com/arangodb/tinkerpop/gremlin/utils/ArangoDBUtil.java
@@ -17,10 +17,12 @@
 package com.arangodb.tinkerpop.gremlin.utils;
 
 import com.arangodb.entity.GraphEntity;
+import com.arangodb.shaded.fasterxml.jackson.databind.ObjectMapper;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraphConfig;
 import com.arangodb.tinkerpop.gremlin.PackageVersion;
 
 import java.io.Serializable;
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,6 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.GraphVariableHelper;
 
 public class ArangoDBUtil {
+    public static final ObjectMapper MAPPER = new ObjectMapper();
 
     private ArangoDBUtil() {
     }
@@ -74,7 +77,7 @@ public class ArangoDBUtil {
         }
     }
 
-    private static boolean supportsDataType(Object value) {
+    public static boolean supportsDataType(Object value) {
         return value == null ||
                 value instanceof Boolean || value instanceof boolean[] ||
                 value instanceof Double || value instanceof double[] ||
@@ -129,6 +132,24 @@ public class ArangoDBUtil {
             }
 
             return Integer.compare(aPatch, bPatch);
+        }
+    }
+
+    public static List<?> arrayToList(Object value) {
+        int length = Array.getLength(value);
+        List<Object> list = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+            list.add(Array.get(value, i));
+        }
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T normalizeValue(Object value) {
+        if (value != null && value.getClass().isArray()) {
+            return (T) ArangoDBUtil.arrayToList(value);
+        } else {
+            return (T) value;
         }
     }
 

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/complex/ComplexArangoDBSuite.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/complex/ComplexArangoDBSuite.java
@@ -16,6 +16,8 @@
 
 package com.arangodb.tinkerpop.gremlin.arangodb.complex;
 
+import com.arangodb.tinkerpop.gremlin.arangodb.process.filter.*;
+import com.arangodb.tinkerpop.gremlin.arangodb.simple.DataTypesTest;
 import org.apache.tinkerpop.gremlin.AbstractGremlinSuite;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.junit.runners.model.InitializationError;
@@ -25,7 +27,14 @@ public class ComplexArangoDBSuite extends AbstractGremlinSuite {
 
     private static final Class<?>[] allTests = new Class<?>[]{
             ComplexElementIdTest.class,
-            ComplexPersistenceTest.class
+            DataTypesTest.class,
+            ComplexPersistenceTest.class,
+            CompareEqFilterTest.class,
+            NotFilterTest.class,
+            OrFilterTest.class,
+            WithinFilterTest.class,
+            AndFilterTest.class,
+            TextFiltersTest.class
     };
 
     public ComplexArangoDBSuite(final Class<?> klass, final RunnerBuilder builder) throws InitializationError {

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/AndFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/AndFilterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.*;
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.process.traversal.TextP;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AndFilterTest extends AbstractGremlinTest {
+
+    @Test
+    public void testEmpty() {
+        ArangoFilter filter = AndFilter.of(Arrays.asList(
+                new CompareEqFilter("a", "str"),
+                EmptyFilter.INSTANCE
+        ));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`a` == \"str\"");
+    }
+
+    @Test
+    public void equalToStringFilter() {
+        ArangoFilter filter = AndFilter.of(Arrays.asList(
+                new CompareEqFilter("a", "str"),
+                new CompareEqFilter("b", 11)
+        ));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("(`d`.`a` == \"str\" AND `d`.`b` == 11)");
+    }
+
+    @Test
+    public void graphTraversalAndFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", "fee");
+        List<String> res = graph.traversal().V()
+                .has("name", TextP.startingWith("f").and(TextP.endingWith("o")))
+                .<String>values("name").toList();
+        assertThat(res)
+                .hasSize(1)
+                .containsExactly("foo");
+    }
+}

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/AndFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/AndFilterTest.java
@@ -32,7 +32,7 @@ public class AndFilterTest extends AbstractGremlinTest {
     public void testEmpty() {
         ArangoFilter filter = AndFilter.of(Arrays.asList(
                 new CompareEqFilter("a", "str"),
-                EmptyFilter.INSTANCE
+                EmptyFilter.instance()
         ));
         assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
         assertThat(filter.toAql("d")).isEqualTo("`d`.`a` == \"str\"");

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/CompareEqFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/CompareEqFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
 
 import com.arangodb.tinkerpop.gremlin.process.filter.CompareEqFilter;

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/CompareEqFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/CompareEqFilterTest.java
@@ -1,0 +1,128 @@
+package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.CompareEqFilter;
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.*;
+
+import static com.arangodb.tinkerpop.gremlin.utils.ArangoDBUtil.normalizeValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class CompareEqFilterTest extends AbstractGremlinTest {
+
+    private final List<?> data = Arrays.asList(
+            null,
+            Boolean.TRUE,
+            Boolean.FALSE,
+            new boolean[]{true, false, true},
+            12.12d,
+            new double[]{1.1d, 2.2d, 3.3d},
+            11,
+            new int[]{1, 2, 3, 4, 5},
+            5_000_000_000L,
+            new long[]{5_000_000_000L, 6_000_000_000L, 7_000_000_000L},
+            "hello",
+            new String[]{"hello", "world", "test"},
+            Arrays.asList(null, true, 2.2d, 22, 5_000_000_000L, "hello"),
+            new HashMap<String, Object>() {{
+                put("k1", null);
+                put("k2", true);
+                put("k3", 2.2d);
+                put("k4", 22);
+                put("k5", 5_000_000_000L);
+                put("k6", "hello");
+            }}
+    );
+
+    private final List<?> unsupportedData = Arrays.asList(
+            new Date(),
+            new java.sql.Date(new Date().getTime()),
+            new Date[]{new Date()},
+            UUID.randomUUID(),
+            BigInteger.TEN,
+            BigDecimal.ONE,
+            Float.NEGATIVE_INFINITY,
+            Float.POSITIVE_INFINITY,
+            1.23f,
+            (byte) 0x22,
+            (short) 11,
+            Void.class
+    );
+
+    @Test
+    public void equalToStringFilter() {
+        CompareEqFilter filter = new CompareEqFilter("field", "str");
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`field` == \"str\"");
+    }
+
+    @Test
+    public void equalToBoolFilter() {
+        CompareEqFilter filter = new CompareEqFilter("field", false);
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`field` == false");
+    }
+
+    @Test
+    public void equalToIntegerFilter() {
+        CompareEqFilter filter = new CompareEqFilter("field", 22);
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`field` == 22");
+    }
+
+    @Test
+    public void equalToNullFilter() {
+        CompareEqFilter filter = new CompareEqFilter("field", null);
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.PARTIAL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`field` == null");
+    }
+
+    @Test
+    public void graphTraversalFilterValues() {
+        data.forEach(this::testGraphTraversalFilterValues);
+        unsupportedData.forEach(this::testUnsupportedGraphTraversalFilterValues);
+    }
+
+    @Test
+    public void idEqualToStringFilter() {
+        Vertex v = graph.addVertex();
+        v.property("value", "foo");
+        List<Vertex> res = graph.traversal().V().hasId(v.id()).has("value", "foo").toList();
+        assertThat(res)
+                .hasSize(1)
+                .allMatch(vertex -> vertex.id().equals(v.id()));
+    }
+
+    @Test
+    public void labelEqualToStringFilter() {
+        graph.addVertex("vertex").property("value", "foo");
+        graph.addVertex("foo").property("value", "foo");
+
+        List<Vertex> res = graph.traversal().V().hasLabel("foo").has("value", "foo").toList();
+        assertThat(res)
+                .hasSize(1)
+                .allMatch(vertex -> vertex.label().equals("foo"));
+    }
+
+    private void testGraphTraversalFilterValues(Object value) {
+        Vertex v = graph.addVertex();
+        v.property("value", value);
+        Object p = graph.traversal().V().has("value", value).values("value").next();
+        assertThat(p).isEqualTo(normalizeValue(value));
+    }
+
+    private void testUnsupportedGraphTraversalFilterValues(Object value) {
+        Throwable thrown = catchThrowable(() -> graph.traversal().V().has("value", value).iterate());
+        assertThat(thrown)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Property value")
+                .hasMessageContaining("of type")
+                .hasMessageContaining("is not supported");
+    }
+}

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/NotFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/NotFilterTest.java
@@ -1,0 +1,70 @@
+package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.ArangoFilter;
+import com.arangodb.tinkerpop.gremlin.process.filter.CompareEqFilter;
+import com.arangodb.tinkerpop.gremlin.process.filter.FilterSupport;
+import com.arangodb.tinkerpop.gremlin.process.filter.NotFilter;
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class NotFilterTest extends AbstractGremlinTest {
+
+    @Test
+    public void neqToStringFilter() {
+        ArangoFilter filter = NotFilter.of(new CompareEqFilter("field", "str"));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("NOT(`d`.`field` == \"str\")");
+    }
+
+    @Test
+    public void neqToBoolFilter() {
+        ArangoFilter filter = NotFilter.of(new CompareEqFilter("field", false));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("NOT(`d`.`field` == false)");
+    }
+
+    @Test
+    public void neqToIntegerFilter() {
+        ArangoFilter filter = NotFilter.of(new CompareEqFilter("field", 22));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("NOT(`d`.`field` == 22)");
+    }
+
+    @Test
+    public void neqToNullFilter() {
+        ArangoFilter filter = NotFilter.of(new CompareEqFilter("field", null));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.NONE);
+        Throwable thrown = catchThrowable(() -> filter.toAql("x"));
+        assertThat(thrown).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void graphTraversalNeqFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", "bar");
+        Object p = graph.traversal().V().has("name", P.neq("foo")).values("name").next();
+        assertThat(p).isEqualTo("bar");
+    }
+
+    @Test
+    public void graphTraversalNeqNullFilter() {
+        graph.addVertex().property("name", null);
+        graph.addVertex().property("name", "bar");
+        graph.addVertex().property("foo", "bar");
+        List<Vertex> res = graph.traversal().V().has("name", P.neq(null)).toList();
+        assertThat(res)
+                .hasSize(1)
+                .allMatch(v -> v.property("name").isPresent())
+                .map(v -> v.value("name"))
+                .first()
+                .isEqualTo("bar");
+    }
+
+}

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/NotFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/NotFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
 
 import com.arangodb.tinkerpop.gremlin.process.filter.ArangoFilter;

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/OrFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/OrFilterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.*;
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrFilterTest extends AbstractGremlinTest {
+
+    @Test
+    public void testEmpty() {
+        ArangoFilter filter = OrFilter.of(Arrays.asList(
+                new CompareEqFilter("a", "str"),
+                EmptyFilter.INSTANCE
+        ));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`a` == \"str\"");
+    }
+
+    @Test
+    public void equalToStringFilter() {
+        ArangoFilter filter = OrFilter.of(Arrays.asList(
+                new CompareEqFilter("a", "str"),
+                new CompareEqFilter("b", 11)
+        ));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("(`d`.`a` == \"str\" OR `d`.`b` == 11)");
+    }
+
+    @Test
+    public void graphTraversalOrFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", "bar");
+        List<String> res = graph.traversal().V()
+                .has("name", P.eq("foo").or(P.eq("bar")))
+                .<String>values("name").toList();
+        assertThat(res)
+                .hasSize(2)
+                .containsExactly("foo", "bar");
+    }
+
+    @Test
+    public void graphTraversalOrNullFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", null);
+        List<Object> res = graph.traversal().V()
+                .has("name", P.eq("foo").or(P.eq(null)))
+                .values("name").toList();
+        assertThat(res)
+                .hasSize(2)
+                .containsExactly("foo", null);
+    }
+}

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/OrFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/OrFilterTest.java
@@ -32,7 +32,7 @@ public class OrFilterTest extends AbstractGremlinTest {
     public void testEmpty() {
         ArangoFilter filter = OrFilter.of(Arrays.asList(
                 new CompareEqFilter("a", "str"),
-                EmptyFilter.INSTANCE
+                EmptyFilter.instance()
         ));
         assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
         assertThat(filter.toAql("d")).isEqualTo("`d`.`a` == \"str\"");

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/TextFiltersTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/TextFiltersTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
 
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
@@ -37,14 +53,14 @@ public class TextFiltersTest extends AbstractGremlinTest {
 
     @Test
     public void textEndingWithFilter() {
-        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "foo\\");
         graph.addVertex().property("value", "bar");
-        List<Vertex> res = graph.traversal().V().has("value", endingWith("oo")).toList();
+        List<Vertex> res = graph.traversal().V().has("value", endingWith("oo\\")).toList();
         assertThat(res)
                 .hasSize(1)
                 .map(v -> v.value("value"))
                 .first()
-                .isEqualTo("foo");
+                .isEqualTo("foo\\");
     }
 
     @Test

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/TextFiltersTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/TextFiltersTest.java
@@ -1,0 +1,110 @@
+package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
+
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.apache.tinkerpop.gremlin.process.traversal.TextP.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TextFiltersTest extends AbstractGremlinTest {
+
+    @Test
+    public void textStartingWithFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", startingWith("fo")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("foo");
+    }
+
+    @Test
+    public void textNotStartingWithFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", notStartingWith("fo")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("bar");
+    }
+
+    @Test
+    public void textEndingWithFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", endingWith("oo")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("foo");
+    }
+
+    @Test
+    public void textNotEndingWithFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", notEndingWith("oo")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("bar");
+    }
+
+    @Test
+    public void textContainingFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", containing("a")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("bar");
+    }
+
+    @Test
+    public void textNotContainingFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", notContaining("a")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("foo");
+    }
+
+    @Test
+    public void textRegexFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", regex("^b.*r$")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("bar");
+    }
+
+    @Test
+    public void textNotRegexFilter() {
+        graph.addVertex().property("value", "foo");
+        graph.addVertex().property("value", "bar");
+        List<Vertex> res = graph.traversal().V().has("value", notRegex("^b.*r$")).toList();
+        assertThat(res)
+                .hasSize(1)
+                .map(v -> v.value("value"))
+                .first()
+                .isEqualTo("foo");
+    }
+
+}

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/WithinFilterTest.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/process/filter/WithinFilterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 ArangoDB GmbH and The University of York
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arangodb.tinkerpop.gremlin.arangodb.process.filter;
+
+import com.arangodb.tinkerpop.gremlin.process.filter.*;
+import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WithinFilterTest extends AbstractGremlinTest {
+
+    @Test
+    public void withinStringFilter() {
+        ArangoFilter filter = new ContainsWithinFilter("a", Arrays.asList("str", 11));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.FULL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`a` IN [\"str\", 11]");
+    }
+
+    @Test
+    public void withinNullFilter() {
+        ArangoFilter filter = new ContainsWithinFilter("a", Arrays.asList("str", null));
+        assertThat(filter.getSupport()).isEqualTo(FilterSupport.PARTIAL);
+        assertThat(filter.toAql("d")).isEqualTo("`d`.`a` IN [\"str\", null]");
+    }
+
+    @Test
+    public void graphTraversalWithinFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", "bar");
+        List<String> res = graph.traversal().V()
+                .has("name", P.within("foo", "bar"))
+                .<String>values("name").toList();
+        assertThat(res)
+                .hasSize(2)
+                .containsExactly("foo", "bar");
+    }
+
+    @Test
+    public void graphTraversalWithinNullFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", null);
+        List<Object> res = graph.traversal().V()
+                .has("name", P.within("foo", null))
+                .values("name").toList();
+        assertThat(res)
+                .hasSize(2)
+                .containsExactly("foo", null);
+    }
+
+    @Test
+    public void graphTraversalWithoutFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", "bar");
+        graph.addVertex().property("name", "baz");
+        List<String> res = graph.traversal().V()
+                .has("name", P.without("foo", "bar"))
+                .<String>values("name").toList();
+        assertThat(res)
+                .hasSize(1)
+                .containsExactly("baz");
+    }
+
+    @Test
+    public void graphTraversalWithoutNullFilter() {
+        graph.addVertex().property("name", "foo");
+        graph.addVertex().property("name", null);
+        graph.addVertex().property("name", "baz");
+        List<Object> res = graph.traversal().V()
+                .has("name", P.without("foo", null))
+                .values("name").toList();
+        assertThat(res)
+                .hasSize(1)
+                .containsExactly("baz");
+    }
+}

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/simple/SimpleArangoDBSuite.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/arangodb/simple/SimpleArangoDBSuite.java
@@ -16,6 +16,7 @@
 
 package com.arangodb.tinkerpop.gremlin.arangodb.simple;
 
+import com.arangodb.tinkerpop.gremlin.arangodb.process.filter.*;
 import org.apache.tinkerpop.gremlin.AbstractGremlinSuite;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalEngine;
 import org.junit.runners.model.InitializationError;
@@ -28,7 +29,13 @@ public class SimpleArangoDBSuite extends AbstractGremlinSuite {
             DataTypesTest.class,
             SimplePersistenceTest.class,
             AqlTest.class,
-            DriverTest.class
+            DriverTest.class,
+            CompareEqFilterTest.class,
+            NotFilterTest.class,
+            OrFilterTest.class,
+            WithinFilterTest.class,
+            AndFilterTest.class,
+            TextFiltersTest.class
     };
 
     public SimpleArangoDBSuite(final Class<?> klass, final RunnerBuilder builder) throws InitializationError {

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexGraphProvider.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexGraphProvider.java
@@ -18,7 +18,6 @@ package com.arangodb.tinkerpop.gremlin.complex;
 
 import com.arangodb.tinkerpop.gremlin.TestGraphProvider;
 
-import com.arangodb.tinkerpop.gremlin.arangodb.complex.ComplexElementIdTest;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraphConfig;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraphConfig.EdgeDef;
 import com.arangodb.tinkerpop.gremlin.utils.ArangoDBConfigurationBuilder;
@@ -36,9 +35,8 @@ public class ComplexGraphProvider extends TestGraphProvider {
     @Override
     protected void configureDataDefinitions(ArangoDBConfigurationBuilder builder, Class<?> test, String testMethodName, LoadGraphWith.GraphData loadGraphWith) {
         // add default vertex and edge cols
-        builder.edgeDefinitions(EdgeDef.of("edge").from("vertex").to("vertex"));
-        if (test == ComplexElementIdTest.class) {
-            builder.orphanCollections("foo", "foo_bar");
-        }
+        builder
+                .edgeDefinitions(EdgeDef.of("edge").from("vertex").to("vertex"))
+                .orphanCollections("foo", "foo_bar");
     }
 }

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraph.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraph.java
@@ -16,12 +16,19 @@
 
 package com.arangodb.tinkerpop.gremlin.complex;
 
+import com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization.ArangoStepStrategy;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraph;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 @Graph.OptIn("com.arangodb.tinkerpop.gremlin.arangodb.complex.ComplexArangoDBSuite")
 public class ComplexTestGraph extends ArangoDBGraph {
+
+    static {
+        TraversalStrategies.GlobalCache.registerStrategies(ComplexTestGraph.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
+                .addStrategies(ArangoStepStrategy.INSTANCE));
+    }
 
     @SuppressWarnings("unused")
     public static ComplexTestGraph open(Configuration configuration) {

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraph.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraph.java
@@ -27,7 +27,7 @@ public class ComplexTestGraph extends ArangoDBGraph {
 
     static {
         TraversalStrategies.GlobalCache.registerStrategies(ComplexTestGraph.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
-                .addStrategies(ArangoStepStrategy.INSTANCE));
+                .addStrategies(ArangoStepStrategy.instance()));
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraphWithoutIdPrefix.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraphWithoutIdPrefix.java
@@ -16,10 +16,12 @@
 
 package com.arangodb.tinkerpop.gremlin.complex;
 
+import com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization.ArangoStepStrategy;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBEdge;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraph;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBVertex;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -88,6 +90,11 @@ import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
         method = "g_V_withSideEffectXsgX_outEXknowsX_subgraphXsgX_name_capXsgX",
         reason = "requires VertexProperty user supplied identifiers")
 public class ComplexTestGraphWithoutIdPrefix extends ArangoDBGraph {
+
+    static {
+        TraversalStrategies.GlobalCache.registerStrategies(ComplexTestGraphWithoutIdPrefix.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
+                .addStrategies(ArangoStepStrategy.INSTANCE));
+    }
 
     @SuppressWarnings("unused")
     public static ComplexTestGraphWithoutIdPrefix open(Configuration configuration) {

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraphWithoutIdPrefix.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/complex/ComplexTestGraphWithoutIdPrefix.java
@@ -93,7 +93,7 @@ public class ComplexTestGraphWithoutIdPrefix extends ArangoDBGraph {
 
     static {
         TraversalStrategies.GlobalCache.registerStrategies(ComplexTestGraphWithoutIdPrefix.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
-                .addStrategies(ArangoStepStrategy.INSTANCE));
+                .addStrategies(ArangoStepStrategy.instance()));
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/simple/SimpleTestGraph.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/simple/SimpleTestGraph.java
@@ -16,8 +16,10 @@
 
 package com.arangodb.tinkerpop.gremlin.simple;
 
+import com.arangodb.tinkerpop.gremlin.process.traversal.strategy.optimization.ArangoStepStrategy;
 import com.arangodb.tinkerpop.gremlin.structure.ArangoDBGraph;
 import org.apache.commons.configuration2.Configuration;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
 @Graph.OptIn(Graph.OptIn.SUITE_STRUCTURE_STANDARD)
@@ -74,6 +76,11 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         method = "g_V_withSideEffectXsgX_outEXknowsX_subgraphXsgX_name_capXsgX",
         reason = "requires VertexProperty user supplied identifiers")
 public class SimpleTestGraph extends ArangoDBGraph {
+
+    static {
+        TraversalStrategies.GlobalCache.registerStrategies(SimpleTestGraph.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
+                .addStrategies(ArangoStepStrategy.INSTANCE));
+    }
 
     @SuppressWarnings("unused")
     public static SimpleTestGraph open(Configuration configuration) {

--- a/src/test/java/com/arangodb/tinkerpop/gremlin/simple/SimpleTestGraph.java
+++ b/src/test/java/com/arangodb/tinkerpop/gremlin/simple/SimpleTestGraph.java
@@ -79,7 +79,7 @@ public class SimpleTestGraph extends ArangoDBGraph {
 
     static {
         TraversalStrategies.GlobalCache.registerStrategies(SimpleTestGraph.class, TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
-                .addStrategies(ArangoStepStrategy.INSTANCE));
+                .addStrategies(ArangoStepStrategy.instance()));
     }
 
     @SuppressWarnings("unused")

--- a/test-console/test.sh
+++ b/test-console/test.sh
@@ -20,5 +20,5 @@ docker cp "$LOCATION"/arangodb.yaml tinkerpop-data:/arangodb
 
 docker run \
   --volumes-from tinkerpop-data \
-  docker.io/tinkerpop/gremlin-console \
+  docker.io/tinkerpop/gremlin-console:3.7.4 \
   -e /arangodb/test.groovy


### PR DESCRIPTION
This PR implements filter pushdown optimization for ArangoDB TinkerPop integration by translating Gremlin predicates into AQL queries. The implementation adds query optimization to reduce data transfer and improve performance.

This PR implements the push down only for filters of type: `org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep`. 

For example this optimizes queries like `g.V().has("value", "foo")`, by reading from the database only the matching vertices.